### PR TITLE
Fixed issue #277 Get-TssSecretSetting unable to Convert

### DIFF
--- a/src/functions/secrets/Get-TssSecretSetting.ps1
+++ b/src/functions/secrets/Get-TssSecretSetting.ps1
@@ -61,7 +61,11 @@ function Get-TssSecretSetting {
                 }
 
                 if ($restResponse) {
-                    [Thycotic.PowerShell.Secrets.DetailSettings]$restResponse
+					$restResponse | ForEach-Object {
+                        $NonEmptyProperties = $_.restResponse.Properties | Where-Object {$_.Value} | Select-Object -ExpandProperty Name
+                        $_ | Select-Object -Property $NonEmptyProperties
+                    }
+                    [Thycotic.PowerShell.Secrets.DetailSettings]$NonEmptyProperties
                 }
             }
         } else {


### PR DESCRIPTION
Done the fix for the issue [Get-TssSecretSetting unable to Convert Value · Issue #277 · thycotic-ps/thycotic.secretserver (github.com)](https://github.com/thycotic-ps/thycotic.secretserver/issues/277)

Root Cause: Secret Server returns the null value in JSON for some of the fields and while converting the JSON into the object it was throwing the exception.

Fix: : filter the null values from the JSON

@Delineakrehl